### PR TITLE
fix building sortable query from ActionController::Parameters in Rails 5

### DIFF
--- a/lib/table_for/base.rb
+++ b/lib/table_for/base.rb
@@ -114,7 +114,7 @@ module TableFor
           next_sort_mode = sort_modes[next_sort_mode_index]
         end
 
-        parameters = view.params.merge(:order => order, :sort_mode => next_sort_mode)
+        parameters = view.params.merge(:order => order, :sort_mode => next_sort_mode).to_unsafe_h
         parameters.delete(:action)
         parameters.delete(:controller)
         url = options[:sort_url] ? options[:sort_url] : ""


### PR DESCRIPTION
I had to add this metthod in Rails 5 because ActionController::Parameters object doesn't return simple hash as default. I don't know how it works with previous versions of Rails.