### PR TITLE
fix deleting :action, :controller from params

### DIFF
--- a/lib/table_for/base.rb
+++ b/lib/table_for/base.rb
@@ -115,11 +115,11 @@ module TableFor
         end
 
         parameters = view.params.merge(:order => order, :sort_mode => next_sort_mode)
+        parameters.delete(:action)
+        parameters.delete(:controller)
         if parameters.respond_to?(:to_unsafe_h)
           parameters = parameters.to_unsafe_h
         end
-        parameters.delete(:action)
-        parameters.delete(:controller)
         url = options[:sort_url] ? options[:sort_url] : ""
         view.link_to view.capture(self, &block), "#{url}?#{parameters.to_query}"
       else


### PR DESCRIPTION
I think the order of actions shoud be changed. As long as parameters object is an instance of ActionController::Parameters parameters.delete(:action), where :action is a Symbol, it will work.

```ruby
[1] pry(#<#<Class:0x0000000b2fe698>>)> params
=> { "order"=>"email",
 "sort_mode"=>"desc",
 "controller"=>"profiles",
 "action"=>"index"}
[2] pry(#<#<Class:0x0000000b2fe698>>)> params.class
=> ActionController::Parameters
[3] pry(#<#<Class:0x0000000b2fe698>>)> params.delete(:action)
=> "index"
[4] pry(#<#<Class:0x0000000b2fe698>>)> params
=> { "order"=>"email",
 "sort_mode"=>"desc",
 "controller"=>"profiles"}
```

But when paameters becomes a regular hash keys turn into Strings. Using parameters.delete(:action) will not work.

```ruby
[5] pry(#<#<Class:0x0000000b2fe698>>)> parameters = params.to_unsafe_h
=> { "order"=>"email",
 "sort_mode"=>"desc",
 "controller"=>"profiles"}
[6] pry(#<#<Class:0x0000000b2fe698>>)> parameters.delete(:controller)
=> nil
[7] pry(#<#<Class:0x0000000b2fe698>>)> parameters
=> { "order"=>"email",
 "sort_mode"=>"desc",
 "controller"=>"profiles"}
```
