### PR TITLE
sort params exclude param by table/column e.g. :page

### DIFF
--- a/lib/table_for/base.rb
+++ b/lib/table_for/base.rb
@@ -115,6 +115,7 @@ module TableFor
         end
 
         parameters = view.params.merge(:order => order, :sort_mode => next_sort_mode)
+        [options[:sort_params_exclude]].flatten.map(&:presence).compact.each { |key| parameters.delete(key.to_s.to_sym) } if options[:sort_params_exclude].present?
         if parameters.respond_to?(:to_unsafe_h)
           parameters = parameters.to_unsafe_h
         end


### PR DESCRIPTION
From my point of view this option is necessary when you work with tables with pagination. When I go to another page and click on a header I expect I will go to the first page with new sort order. Without excluding :page parameter I go to the same page with different ordering.